### PR TITLE
fix: compteur visiteurs à 0 + badges profil non clicables

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { DesktopSidebar } from '@/components/layout/DesktopSidebar';
 import WelcomePromptWrapper from '@/components/features/auth/WelcomePromptWrapper';
 import FlashMessage from '@/components/features/common/FlashMessage';
 import { GamificationProvider } from '@/components/features/gamification/GamificationProvider';
+import { PageViewTracker } from '@/components/layout/PageViewTracker';
 
 const inter = Inter({
   variable: '--font-inter',
@@ -86,6 +87,7 @@ export default function RootLayout({
           <WelcomePromptWrapper />
           <FlashMessage />
           <GamificationProvider />
+          <PageViewTracker />
         </Providers>
       </body>
     </html>

--- a/src/components/features/profile/ProfileTabs.tsx
+++ b/src/components/features/profile/ProfileTabs.tsx
@@ -19,10 +19,16 @@ export default function ProfileTabs({ userId, isOwnProfile }: ProfileTabsProps) 
   const [activeTab, setActiveTab] = useState('submissions');
 
   useEffect(() => {
-    const hash = window.location.hash.slice(1);
-    if (VALID_TABS.includes(hash as (typeof VALID_TABS)[number])) {
-      setActiveTab(hash);
-    }
+    const syncHash = () => {
+      const hash = window.location.hash.slice(1);
+      if (VALID_TABS.includes(hash as (typeof VALID_TABS)[number])) {
+        setActiveTab(hash);
+      }
+    };
+
+    syncHash();
+    window.addEventListener('hashchange', syncHash);
+    return () => window.removeEventListener('hashchange', syncHash);
   }, []);
 
   const handleTabChange = (value: string) => {

--- a/src/components/layout/PageViewTracker.tsx
+++ b/src/components/layout/PageViewTracker.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { usePageView } from '@/hooks/use-page-view';
+
+export function PageViewTracker() {
+  const pathname = usePathname();
+  usePageView(pathname);
+  return null;
+}


### PR DESCRIPTION
- Brancher usePageView via PageViewTracker dans le layout (fire-and-forget)
- Écouter hashchange dans ProfileTabs pour réagir aux clics sur les badges