### PR TITLE
fix: restaurer les couleurs distinctes des badges de catégories

### DIFF
--- a/src/lib/constants/categories.ts
+++ b/src/lib/constants/categories.ts
@@ -14,22 +14,22 @@ export interface CategoryDef {
 }
 
 export const CATEGORIES: CategoryDef[] = [
-  { slug: 'Institutions', label: 'Institutions', icon: Landmark, color: 'text-text-muted', bgColor: 'bg-surface-elevated' },
-  { slug: 'Culture', label: 'Culture', icon: Palette, color: 'text-text-muted', bgColor: 'bg-surface-elevated' },
-  { slug: 'Recherche', label: 'Recherche', icon: FlaskConical, color: 'text-text-muted', bgColor: 'bg-surface-elevated' },
-  { slug: 'Aménagement', label: 'Amenagement', icon: MapPin, color: 'text-text-muted', bgColor: 'bg-surface-elevated' },
-  { slug: 'Industrie', label: 'Industrie', icon: Factory, color: 'text-text-muted', bgColor: 'bg-surface-elevated' },
-  { slug: 'Numérique', label: 'Numerique', icon: Monitor, color: 'text-text-muted', bgColor: 'bg-surface-elevated' },
-  { slug: 'Défense', label: 'Defense', icon: Shield, color: 'text-text-muted', bgColor: 'bg-surface-elevated' },
-  { slug: 'Travail', label: 'Travail', icon: Briefcase, color: 'text-text-muted', bgColor: 'bg-surface-elevated' },
-  { slug: 'Environnement', label: 'Environnement', icon: Leaf, color: 'text-text-muted', bgColor: 'bg-surface-elevated' },
-  { slug: 'Agriculture', label: 'Agriculture', icon: Wheat, color: 'text-text-muted', bgColor: 'bg-surface-elevated' },
-  { slug: 'Collectivités', label: 'Collectivites', icon: Building2, color: 'text-text-muted', bgColor: 'bg-surface-elevated' },
-  { slug: 'Social', label: 'Social', icon: Heart, color: 'text-text-muted', bgColor: 'bg-surface-elevated' },
-  { slug: 'Énergie', label: 'Energie', icon: Zap, color: 'text-text-muted', bgColor: 'bg-surface-elevated' },
-  { slug: 'Transport', label: 'Transport', icon: Train, color: 'text-text-muted', bgColor: 'bg-surface-elevated' },
-  { slug: 'Éducation', label: 'Education', icon: GraduationCap, color: 'text-text-muted', bgColor: 'bg-surface-elevated' },
-  { slug: 'Santé', label: 'Sante', icon: Stethoscope, color: 'text-text-muted', bgColor: 'bg-surface-elevated' },
+  { slug: 'Institutions', label: 'Institutions', icon: Landmark, color: 'text-amber-500', bgColor: 'bg-amber-500/15' },
+  { slug: 'Culture', label: 'Culture', icon: Palette, color: 'text-purple-400', bgColor: 'bg-purple-400/15' },
+  { slug: 'Recherche', label: 'Recherche', icon: FlaskConical, color: 'text-cyan-400', bgColor: 'bg-cyan-400/15' },
+  { slug: 'Aménagement', label: 'Amenagement', icon: MapPin, color: 'text-orange-400', bgColor: 'bg-orange-400/15' },
+  { slug: 'Industrie', label: 'Industrie', icon: Factory, color: 'text-slate-400', bgColor: 'bg-slate-400/15' },
+  { slug: 'Numérique', label: 'Numerique', icon: Monitor, color: 'text-blue-400', bgColor: 'bg-blue-400/15' },
+  { slug: 'Défense', label: 'Defense', icon: Shield, color: 'text-red-400', bgColor: 'bg-red-400/15' },
+  { slug: 'Travail', label: 'Travail', icon: Briefcase, color: 'text-yellow-400', bgColor: 'bg-yellow-400/15' },
+  { slug: 'Environnement', label: 'Environnement', icon: Leaf, color: 'text-green-400', bgColor: 'bg-green-400/15' },
+  { slug: 'Agriculture', label: 'Agriculture', icon: Wheat, color: 'text-lime-400', bgColor: 'bg-lime-400/15' },
+  { slug: 'Collectivités', label: 'Collectivites', icon: Building2, color: 'text-indigo-400', bgColor: 'bg-indigo-400/15' },
+  { slug: 'Social', label: 'Social', icon: Heart, color: 'text-pink-400', bgColor: 'bg-pink-400/15' },
+  { slug: 'Énergie', label: 'Energie', icon: Zap, color: 'text-yellow-300', bgColor: 'bg-yellow-300/15' },
+  { slug: 'Transport', label: 'Transport', icon: Train, color: 'text-teal-400', bgColor: 'bg-teal-400/15' },
+  { slug: 'Éducation', label: 'Education', icon: GraduationCap, color: 'text-violet-400', bgColor: 'bg-violet-400/15' },
+  { slug: 'Santé', label: 'Sante', icon: Stethoscope, color: 'text-rose-400', bgColor: 'bg-rose-400/15' },
 ];
 
 const CATEGORY_MAP = new Map(CATEGORIES.map((c) => [c.slug, c]));


### PR DESCRIPTION
Les couleurs avaient été remplacées par du monochrome (text-text-muted) lors du commit gamification. Restauration des couleurs originales : amber, purple, cyan, orange, slate, blue, red, yellow, green, lime, indigo, pink, teal, violet, rose.

Closes #12